### PR TITLE
Use HKDF-SHA-256 derivation instead of 'pure' SHA-256 digests

### DIFF
--- a/src/iota.js
+++ b/src/iota.js
@@ -21,7 +21,14 @@ function bn2b64(n) {
 async function iota(secret64) {
   // Digest the input
   const secret = base64.parse(secret64);
-  const digest = await cs.digest("SHA-256", secret);
+  const salg = {
+    name: "HKDF",
+    hash: "SHA-256",
+    salt: Buffer.from("iota"),
+    info: Buffer.alloc(0)
+  };
+  const skey = await cs.importKey("raw", secret, salg, false, ["deriveBits"]);
+  const digest = await cs.deriveBits(salg, skey, 256);
 
   // Convert it to an integer and compute the resulting key pair
   const arr = Array.from(new Uint8Array(digest));

--- a/src/treekem.js
+++ b/src/treekem.js
@@ -25,7 +25,14 @@ function xor(a, b) {
 
 async function hash(x64) {
   const x = base64.parse(x64);
-  const d = await cs.digest("SHA-256", x);
+  const alg = {
+    name: "HKDF",
+    hash: "SHA-256",
+    salt: Buffer.from("tree-hash"),
+    info: Buffer.alloc(0)
+  };
+  const xkey = await cs.importKey("raw", x, alg, false, ["deriveBits"]);
+  const d = await cs.deriveBits(alg, xkey, 256);
   return base64.stringify(d);
 }
 


### PR DESCRIPTION
This proposes a change to `iota` and tree `hash` to use HKDF-SHA-256 derivation instead of SHA-256 digests.  This flavor uses a defined `salt` and an empty `info`.

Using a salted algorithm mitigates a problem that pure digests can run into, with inadvertent exposure of the (source of the) private key to siblings.

It might need to be reflected in the specs, if accepted.