### PR TITLE
Remove without double-join

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ function addMember(m) {
 
   // Add a tree
   let index = m.index;
-  let divID = "tree" + index;
+  let divID = `tree-${index}`;
   let tag = $(`<div class="number">${index}</div>`);
   let div = $(`<div id="${divID}" class="tree"></div>`);
   div.append(tag);
@@ -79,10 +79,32 @@ function addMember(m) {
   renderers.push(r);
 
   // Add an update button
-  let buttonID = "update" + index;
-  let button = $(`<button class="update">Update(${index})</button>`);
-  button.click(lockWrap(() => { return update(index); }));
-  $("#buttons").append(button);
+  let ubutton = $(`<button class="update">Update(${index})</button>`);
+  ubutton.attr("id", `btn-update-${index}`);
+  ubutton.click(lockWrap(() => { return update(index); }));
+  $("#buttons").append(ubutton);
+
+  // Add a delete button
+  if (index != 0) {
+    let rbutton = $(`<button class="remove">Remove(${index})</button>`);
+    rbutton.attr("id", `btn-remove-${index}`);
+    rbutton.click(lockWrap(() => { return remove(index); }));
+    $("#buttons").append(rbutton);
+  }
+
+  // Add padding
+  $("#buttons").append(document.createTextNode(' '));
+}
+
+function removeMember(index) {
+  members = members.filter(m => m.index != index);
+
+  delete renderers[index];
+
+  // Remove the associated DOM elements
+  $(`#tree-${index}`).remove();
+  $(`#btn-update-${index}`).remove();
+  $(`#btn-remove-${index}`).remove();
 }
 
 async function userAdd() {
@@ -118,7 +140,8 @@ async function groupAdd() {
 
 async function update(k) {
   let leaf = base64.random(32);
-  let update = await members[k].update(leaf);
+  let member = members.filter(m => m.index == k)[0];
+  let update = await member.update(leaf);
   
   for (m2 of members) {
     if (m2.index == k) {
@@ -128,6 +151,22 @@ async function update(k) {
     }
     renderers[m2.index].render(m2.size, m2.nodes);
   }
+}
+
+async function remove(k) {
+  let leaf = base64.random(32);
+  let remove = await members[0].remove(leaf, k);
+
+  for (m2 of members) {
+    if (m2.index == k) {
+      continue;
+    }
+
+    await m2.handleRemove(remove);
+    renderers[m2.index].render(m2.size, m2.nodes);
+  }
+
+  removeMember(k);
 }
 
 $(document).ready(async () => {

--- a/src/art-state.js
+++ b/src/art-state.js
@@ -76,7 +76,10 @@ class ARTState {
     return { path: path };
   }
   
-  remove(index) {/* TODO */}
+  async remove(index) {
+    /* TODO */
+    return {};
+  }
 
   get groupInitKey() {
     return {
@@ -103,7 +106,9 @@ class ARTState {
     await this.art.merge(update.path);
   }
   
-  handleRemove(remove) {/* TODO */}
+  async handleRemove(remove) {
+    /* TODO */
+  }
 }
 
 module.exports = ARTState;

--- a/src/blank.js
+++ b/src/blank.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const tm = require('./tree-math.js');
+
+let state = {
+  size: 0,
+  nodes: [],
+  known: [],
+
+  hasPriv: function(i, priv) {
+    return this.known[i].filter(x => priv.startsWith(x)).length > 0;
+  }
+}
+
+function createNode(val, i) {
+  let priv = val + 'x'.repeat(i);
+  return {
+    priv: priv,
+    pub: priv.toUpperCase(),
+  };
+}
+
+function formatNode(node) {
+  return `(${node.priv}, ${node.pub})`;
+}
+
+module.exports = {
+  dump: function dump() {
+    console.log("=====");
+    console.log("Size:", state.size);
+    console.log("Nodes:");
+    for (let i=0; i<tm.nodeWidth(state.size); ++i) {
+      let level = tm.level(i);
+      let pad = "   ".repeat(level)
+      let contents = (state.nodes[i])? formatNode(state.nodes[i]) : "_";
+      console.log(`  ${pad}${contents}`); 
+    }
+
+    console.log("Known:");
+    for (let i=0; i<state.size; ++i) {
+      console.log(`  ${i}: ${state.known[i].join(' ')}`);
+    }
+  },
+
+  alloc: function alloc(size) {
+    state.size = size;
+
+    while (state.nodes.length < tm.nodeWidth(size)) {
+      state.nodes.push(null);
+    }
+
+    while (state.known.length < size) {
+      state.known.push([]);
+    }
+  },
+
+  set: function set(k, val) {
+    let dirpath = tm.dirpath(2*k, state.size);
+    dirpath.push(tm.root(state.size));
+
+    let old = dirpath.map(n => state.nodes[n]);
+
+    dirpath.map((n, i) => {
+      let node = createNode(val, i);
+      state.nodes[n] = node; 
+
+      let L = tm.left(n), R = tm.right(n, state.size);
+      let child = (dirpath.includes(L))? R : L;
+      if (!state.nodes[child]) {
+        return;
+      }
+
+      let childPriv = state.nodes[child].priv;
+      let oldPriv = (old[i])? old[i].priv : null;
+      for (let i in state.known) {
+        if (!state.hasPriv(i, childPriv)) {
+          continue;
+        }
+
+        state.known[i].push(node.priv);
+
+        let oldi = state.known[i].indexOf(oldPriv);
+        if (oldi > -1) {
+          state.known[i].splice(oldi, 1);
+        }
+      }
+    });
+
+    state.known[k].push(val);
+    let oldPriv = (old[0])? old[0].priv : null;
+    let oldi = state.known[k].indexOf(oldPriv);
+    if (oldi > -1) {
+      state.known[k].splice(oldi, 1);
+    }
+  },
+
+  // A nodes private key is held by a leaf iff it that leaf is in
+  // the shadow of the node
+  verify: function verify() {
+    for (let n in state.nodes) {
+      if (!state.nodes[n]) {
+        continue;
+      }
+
+      n = parseInt(n);
+      let priv = state.nodes[n].priv;
+      let shadow = tm.shadow(n, state.size).filter(x => !(x & 1)).map(x => x/2);
+      let hasPriv = [...Array(state.size).keys()].filter(i => state.hasPriv(i, priv));
+
+      let shadowSet = {};
+      for (let x of shadow) {
+        shadowSet[x] = true;
+      }
+      for (let x of hasPriv) {
+        if (!shadowSet[x]) {
+          return false;
+        }
+      }
+    }
+    
+    return true;
+  },
+
+  test: function test() {
+    this.alloc(7);
+    this.set(0, 'a');
+    this.set(1, 'b');
+    this.set(2, 'c');
+    this.dump();
+    console.log(this.verify());
+  },
+};
+
+
+
+

--- a/src/flat-state.js
+++ b/src/flat-state.js
@@ -60,7 +60,10 @@ class FlatState {
     };
   }
   
-  remove(index) {/* TODO */}
+  async remove(index) {
+    /* TODO */
+    return {};
+  }
 
   get groupInitKey() {
     let publicNodes = {};
@@ -92,7 +95,9 @@ class FlatState {
     this.nodes[2 * update.from].public = update.public;
   }
   
-  handleRemove(remove) {/* TODO */}
+  async handleRemove(remove) {
+    /* TODO */
+  }
 }
 
 module.exports = FlatState;

--- a/src/tree-math.js
+++ b/src/tree-math.js
@@ -146,6 +146,19 @@ function frontier(n) {
   return f;
 }
 
+function shadow(x, n) {
+  let h = level(x);
+  let L = x;
+  let R = x;
+  while (h > 0) {
+    L = left(L);
+    R = right(R, n);
+    h -= 1;
+  }
+
+  return [...Array(R - L + 1).keys()].map(x => x + L);
+}
+
 function leaves(n) {
   return [...Array(n).keys()].map(x => 2*x);
 }
@@ -208,7 +221,7 @@ function testRelations() {
     { l: "sibling", f: x => sibling(x, n), a: aSibling },
   ];
 
-  for (c of cases) {
+  for (let c of cases) {
     let q = index.map(c.f);
     if (!arrayEqual(q, c.a)) {
       console.log(c.l, q, c.a);
@@ -297,6 +310,30 @@ function testPaths() {
     [17, 7]
   ];
 
+  const aShadow = [
+    [0],
+    [0, 1, 2],
+    [2],
+    [0, 1, 2, 3, 4, 5, 6],
+    [4],
+    [4, 5, 6],
+    [6],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    [8],
+    [8, 9, 10],
+    [10],
+    [8, 9, 10, 11, 12, 13, 14],
+    [12],
+    [12, 13, 14],
+    [14],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    [16],
+    [16, 17, 18],
+    [18],
+    [16, 17, 18, 19, 20],
+    [20],
+  ];
+
   for (let x = 0; x < nodeWidth(n); x += 1) {
     let d = dirpath(x, n);
     if (!arrayEqual(d, aDirpath[x])) {
@@ -308,6 +345,12 @@ function testPaths() {
     if (!arrayEqual(c, aCopath[x])) {
       console.log('copath', c, aCopath[x]);
       throw 'copath';
+    }
+
+    let s = shadow(x, n);
+    if (!arrayEqual(s, aShadow[x])) {
+      console.log('shadow', s, aShadow[x]);
+      throw 'shadow';
     }
   }
   
@@ -339,6 +382,7 @@ module.exports = {
   frontier: frontier,
   dirpath: dirpath,
   copath: copath,
+  shadow: shadow,
   leaves: leaves,
 
   test: test,

--- a/src/treekem-state.js
+++ b/src/treekem-state.js
@@ -93,7 +93,7 @@ class TreeKEMState {
     return {
       index: index,
       ciphertexts: ct.ciphertexts,
-      nodes: ct.nodes,
+      subtreeHeads: ct.subtreeHeads,
     };
   }
 
@@ -130,9 +130,15 @@ class TreeKEMState {
   }
   
   async handleRemove(remove) {
+    console.log(">>> remove", this.index, remove);
     let pt = await this.tkem.decrypt(remove.index, remove.ciphertexts);
+    console.log('--- remove');
     this.tkem.merge(pt.root);
+    console.log('--- remove');
+    this.tkem.merge(remove.subtreeHeads, true);
+    console.log('--- remove');
     this.tkem.remove(remove.index);
+    console.log('<<< remove');
   }
 }
 

--- a/src/treekem-state.js
+++ b/src/treekem-state.js
@@ -55,7 +55,7 @@ class TreeKEMState {
 
   static async join(leaf, groupInitKey) {
     let tkem = await TreeKEM.fromFrontier(groupInitKey.size, groupInitKey.frontier, leaf);
-    let ct = await tkem.encrypt(leaf)
+    let ct = await tkem.encrypt(leaf, tkem.index)
     return {
       ciphertexts: ct.ciphertexts,
       nodes: ct.nodes,
@@ -80,7 +80,7 @@ class TreeKEMState {
   }
 
   async update(leaf) {
-    let ct = await this.tkem.encrypt(leaf);
+    let ct = await this.tkem.encrypt(leaf, this.tkem.index);
     return {
       from: this.tkem.index,
       ciphertexts: ct.ciphertexts,
@@ -88,7 +88,14 @@ class TreeKEMState {
     }
   }
   
-  remove(index) {/* TODO */}
+  async remove(leaf, index) {
+    let ct = await this.tkem.encrypt(leaf, index);
+    return {
+      index: index,
+      ciphertexts: ct.ciphertexts,
+      nodes: ct.nodes,
+    };
+  }
 
   get groupInitKey() {
     return {
@@ -122,7 +129,11 @@ class TreeKEMState {
     this.tkem.merge(pt.nodes);
   }
   
-  handleRemove(remove) {/* TODO */}
+  async handleRemove(remove) {
+    let pt = await this.tkem.decrypt(remove.index, remove.ciphertexts);
+    this.tkem.merge(pt.root);
+    this.tkem.remove(remove.index);
+  }
 }
 
 module.exports = TreeKEMState;


### PR DESCRIPTION
TreeKEM allows removal to be done without double-join, at the cost of fragmenting the tree.  This PR implements such a removal process in the TreeKEM bits of this code.  It also adds `blanks.js`, which is a small testing framework for TreeKEM ideas, and should probably be deleted later.